### PR TITLE
multivalue field can have empty string

### DIFF
--- a/AikumaCloudStorage/src/org/lp20/aikuma/storage/FusionIndex.java
+++ b/AikumaCloudStorage/src/org/lp20/aikuma/storage/FusionIndex.java
@@ -118,7 +118,7 @@ public class FusionIndex implements Index {
         for (int i = 0; i < columns.size(); i++) {
             String key = columns.get(i);
             String value = row.get(i);
-            if (fields.get(key).multiValue) {
+            if (fields.get(key).multiValue && value.length() > 0) {
                 value = value.replace('|', ',').substring(1, value.length() - 1);
             }
             ret.put(key, value);


### PR DESCRIPTION
I observed that the value of a multivalue field can be an empty string.
