### PR TITLE
FusionTable internal updates

### DIFF
--- a/AikumaCloudStorage/demo/IndexTool.java
+++ b/AikumaCloudStorage/demo/IndexTool.java
@@ -124,6 +124,8 @@ public class IndexTool {
                 index.dropTable(tableIdToDrop);
             } else if ("list".equals(action)) {
                 index.listTables();
+            } else if ("generate_schema".equals(action)) {
+                index.generateSchema();
             }
 
         } catch (InvalidAccessTokenException e) {
@@ -294,5 +296,25 @@ public class IndexTool {
             e.printStackTrace();
         }
     }
+    @SuppressWarnings("unchecked")
+    private void generateSchema() {
+        JSONObject schema = new JSONObject();
+        schema.put("name", "aikuma_metadata");
+        schema.put("isExportable", false);
+        schema.put("description", "Main metadata table for Aikuma cloud storage");
+        JSONArray columns = new JSONArray();
+        JSONObject id = new JSONObject();
+        id.put("name", "identifier");
+        id.put("type", "STRING");
+        columns.add(id);
+        for (FusionIndex.MetadataField f : FusionIndex.MetadataField.values()) {
+            JSONObject tmp = new JSONObject();
+            tmp.put("name", f.getName());
+            tmp.put("type", f.getType());
+            columns.add(tmp);
+        }
+        schema.put("columns", columns);
+        System.out.println(schema.toJSONString());
 
+    }
 }

--- a/AikumaCloudStorage/src/org/lp20/aikuma/storage/FusionIndex.java
+++ b/AikumaCloudStorage/src/org/lp20/aikuma/storage/FusionIndex.java
@@ -42,8 +42,8 @@ public class FusionIndex implements Index {
         SPEAKERS("speakers", true, true),
         TAGS("tags", false, true),
         DISCOURSE_TYPES("discourse_types", false, true),
-        DATE_BACKED_UP("date_backedup", false, false, "yyyy-mm-dd'T'hh:mm:ssZ"),
-        DATE_APPROVED("date_approved", false, false, "yyyy-mm-dd'T'hh:mm:ssZ"),
+        DATE_BACKED_UP("date_backedup", false, false, "yyyy-mm-dd'T'hh:mm:ssZ", "DATETIME"),
+        DATE_APPROVED("date_approved", false, false, "yyyy-mm-dd'T'hh:mm:ssZ", "DATETIME"),
         METADATA("metadata", false, false),
         USER_ID("user_id", true, false);
 
@@ -62,20 +62,25 @@ public class FusionIndex implements Index {
         public String getFormat() {
             return format;
         }
+        public String getType(){
+            return type;
+        }
 
         private String name;
         private boolean required;
         private boolean multivalue;
         private String format;
+        private String type;
 
-        private MetadataField(String name, boolean required, boolean multivalue, String format) {
+        private MetadataField(String name, boolean required, boolean multivalue, String format, String type) {
             this.name = name;
             this.required = required;
             this.multivalue = multivalue;
             this.format = format;
+            this.type = type;
         }
         private MetadataField(String name, boolean required, boolean multivalue) {
-            this(name, required, multivalue, null);
+            this(name, required, multivalue, null, "STRING");
         }
         private static Map<String, MetadataField> nameToValue;
         static  {


### PR DESCRIPTION
I changed the way that the FusionIndex class stores the information about fields in the database, and that information is now available in a public enum on the class. I also changed the IndexTool class to allow generating the JSON schema from the code directly, reducing maintenance overhead.

@hleeldc Could you look at this for me?
