### PR TITLE
Changed date format and validation behavior

### DIFF
--- a/AikumaCloudStorage/src/org/lp20/aikuma/storage/FusionIndex.java
+++ b/AikumaCloudStorage/src/org/lp20/aikuma/storage/FusionIndex.java
@@ -42,11 +42,11 @@ public class FusionIndex implements Index {
         SPEAKERS("speakers", true, true),
         TAGS("tags", false, true),
         DISCOURSE_TYPES("discourse_types", false, true),
-        DATE_BACKED_UP("date_backedup", false, false, "yyyy-mm-dd'T'hh:mm:ssZ", "DATETIME"),
-        DATE_APPROVED("date_approved", false, false, "yyyy-mm-dd'T'hh:mm:ssZ", "DATETIME"),
+        DATE_BACKED_UP("date_backedup", false, false, "yyyy-MM-dd'T'HH:mm:ss'Z'", "DATETIME"),
+        DATE_APPROVED("date_approved", false, false, "yyyy-MM-dd'T'HH:mm:ss'Z'", "DATETIME"),
         METADATA("metadata", false, false),
         USER_ID("user_id", true, false),
-        DATE_PROCESSED("date_processed", false, false, "yyyy-mm-dd'T'hh:mm:ssZ", "DATETIME");
+        DATE_PROCESSED("date_processed", false, false, "yyyy-MM-dd'T'HH:mm:ss'Z'", "DATETIME");
 
         public String getName() {
             return name;
@@ -397,7 +397,7 @@ public class FusionIndex implements Index {
             String name = f.getName();
             if (isInsert && f.isRequired( )&& !metadata.containsKey(name))
                 throw new IllegalArgumentException("Missing required field " + name);
-            if (f.getFormat() != null) {
+            if (f.getFormat() != null && metadata.containsKey(name)) {
                 // TODO: this assumes all formats are date formats; it should probably be different
                 try {
                     SimpleDateFormat sdf = new SimpleDateFormat(f.getFormat());


### PR DESCRIPTION
- I think there was some problem with date format specifier where "mm" (minute in hour) was used instead of "MM" (month of year), and "hh" (hour in am/pm (1-12)) was used instead of "HH" (hour in day (0-23)).
- It had a timezone specifier which allowed RFC 822 time zone like "-0500". I changed this so that time string always ends with character "Z", meaning that it's UTC. This has an impact on the Aikuma google drive backup process.
- When I wanted to update only one field (date_processed in particular), the validation methods threw an exception because my metadata didn't have other date fields (date_approved and date_backedup). I thought this was a bug.
