### PR TITLE
Added central_data_store_uri field

### DIFF
--- a/AikumaCloudStorage/src/org/lp20/aikuma/storage/FusionIndex.java
+++ b/AikumaCloudStorage/src/org/lp20/aikuma/storage/FusionIndex.java
@@ -36,6 +36,7 @@ public class FusionIndex implements Index {
 
     public static enum MetadataField {
         DATA_STORE_URI("data_store_uri", true, false),
+        CENTRAL_DATA_STORE_URL("central_data_store_uri", false, false),
         ITEM_ID("item_id", true, false),
         FILE_TYPE("file_type", true, false),
         LANGUAGES("languages", true, true),


### PR DESCRIPTION
Archived files can be in both private google drive and the central google drive. Users of the data can download files from either, but we don't have a field to publish the central download url in the fusion table.
