### PR TITLE
Implement full metadata row processing for search

### DIFF
--- a/AikumaCloudStorage/demo/IndexTool.java
+++ b/AikumaCloudStorage/demo/IndexTool.java
@@ -1,10 +1,7 @@
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
-import org.lp20.aikuma.storage.FusionIndex;
-import org.lp20.aikuma.storage.GoogleAuth;
-import org.lp20.aikuma.storage.InvalidAccessTokenException;
-import org.lp20.aikuma.storage.Utils;
+import org.lp20.aikuma.storage.*;
 
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -102,7 +99,7 @@ public class IndexTool {
                 index.approveItem(identifier);
             } else if ("search".equals(action)) {
                 Map<String,String> criteria = new HashMap<String, String>();
-                criteria.put("speakers", "bob");
+                criteria.put("file_type", "source");
                 index.doSearch(criteria);
 
             } else if ("create".equals(action)) {
@@ -266,8 +263,17 @@ public class IndexTool {
     }
     private void doSearch(Map<String, String> params) {
         FusionIndex fi = getFusionIndex();
-        for (String id : fi.search(params)) {
-            System.out.println(id);
+        if (false) {
+            for (String id : fi.search(params)) {
+                System.out.println(id);
+            }
+        } else {
+            fi.search(params, new Index.SearchResultProcessor() {
+                @Override
+                public void process(Map<String, String> result) {
+                    System.out.println(result);
+                }
+            });
         }
     }
 

--- a/AikumaCloudStorage/src/org/lp20/aikuma/storage/Index.java
+++ b/AikumaCloudStorage/src/org/lp20/aikuma/storage/Index.java
@@ -22,6 +22,8 @@ public interface Index {
 	 */
 	public abstract List<String> search(Map<String,String> constraints);
 
+    public abstract void search(Map<String, String> constraints, SearchResultProcessor processor);
+
 	/**
 	 * Index an item. If item already exists, it gets updated.
 	 * For metadata, the following keys are required:
@@ -35,6 +37,9 @@ public interface Index {
 	 * @param identifier
 	 * @param metadata
 	 */
+
+
+
 	public abstract boolean index(String identifier, Map<String,String> metadata);
 
 
@@ -44,5 +49,11 @@ public interface Index {
      * @param metadata  entry metadata
      */
     public abstract boolean update(String identifier, Map<String,String> metadata);
+
+
+
+    public interface SearchResultProcessor {
+        public void process(Map<String, String> result);
+    }
 
 }


### PR DESCRIPTION
Hi @hleeldc and @lisaslyis,

Here's the implementation of the fix for issue #311 

The list of changes is below. I've tested the code and it seemed to work as desired. If there are further issues, please let me know and I'll fix them.
- Added SearchResultProcessor interface to Index, which has one method -
  process - that accepts a Map<String, String> that represents a single
  metadata row returned in a search. The array looks like what you'd get back
  from a call to getItemMetadata, with the identifier included in the map.
- Add override method for search in Index, accepting a
  SearchResultProcessor
- Implement override in FusionIndex
- Change indexTool search function to exercise the above
