### PR TITLE
fix FusionIndex bug about apostrophe

### DIFF
--- a/AikumaCloudStorage/src/org/lp20/aikuma/storage/FusionIndex.java
+++ b/AikumaCloudStorage/src/org/lp20/aikuma/storage/FusionIndex.java
@@ -401,7 +401,7 @@ public class FusionIndex implements Index {
             }  else header = true;
             String key = e.getKey();
             fieldList.append((key));
-            String value = e.getValue().replaceAll("'", "\'");
+            String value = e.getValue().replaceAll("'", "\\\\'");
             if (MetadataField.byName(key).isMultivalue()) {
                 value = "|" + value.replaceAll("\\s*,\\s*", "|") + "|";
             }


### PR DESCRIPTION
Apostrophe has be to escaped for Fusion Tables query but it was not
being done properly. This fixes issue #349.
