### PR TITLE
Add an activity for debugging cloud storage

### DIFF
--- a/Aikuma/AndroidManifest.xml
+++ b/Aikuma/AndroidManifest.xml
@@ -168,6 +168,12 @@
 				<meta-data android:name="android.support.PARENT_ACTIVITY"
 					android:value="org.lp20.aikuma.MainActivity" />
 		</activity>
+		<activity android:name="org.lp20.aikuma.ui.DebugInfo"
+				android:label="@string/title_activity_debug_info"
+				android:parentActivityName=".AikumaActivity" >
+				<meta-data android:name="android.support.PARENT_ACTIVITY"
+					android:value="AikumaActivity" />
+		</activity>
 
 		<service android:name="org.lp20.aikuma.service.GoogleCloudService" />
     </application>

--- a/Aikuma/res/layout/activity_debug_info.xml
+++ b/Aikuma/res/layout/activity_debug_info.xml
@@ -1,0 +1,189 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    tools:context="org.lp20.aikuma.ui.DebugInfo">
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/linearLayout"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentLeft="true">
+
+        <Button
+            style="?android:attr/buttonStyleSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Get access token"
+            android:id="@+id/button1"
+            android:onClick="runAuth" />
+
+        <Button
+            style="?android:attr/buttonStyleSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Clear"
+            android:id="@+id/button3"
+            android:onClick="clearLog" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/buttonBox"
+        android:layout_below="@+id/linearLayout">
+
+        <Button
+            style="?android:attr/buttonStyleSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="List docs"
+            android:id="@+id/button2"
+            android:onClick="listDocs" />
+
+        <Button
+            style="?android:attr/buttonStyleSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="List ids"
+            android:id="@+id/button"
+            android:onClick="listIDs" />
+    </LinearLayout>
+
+    <TableLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/tableLayout"
+        android:layout_below="@+id/buttonBox">
+
+        <TableRow
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:text="Package name:"
+                android:id="@+id/textView2"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:id="@+id/txtPkgName" />
+        </TableRow>
+
+        <TableRow
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:text="Fingerprint:"
+                android:id="@+id/textView4"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:id="@+id/txtFingerprint" />
+        </TableRow>
+
+        <TableRow
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="email:"
+                android:id="@+id/textView"/>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:id="@+id/txtEmail" />
+        </TableRow>
+
+        <TableRow
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:text="old token:"
+                android:id="@+id/textView5" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:id="@+id/txtOldToken" />
+        </TableRow>
+
+        <TableRow
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:text="access token:"
+                android:id="@+id/textView3"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:id="@+id/txtAccessToken" />
+        </TableRow>
+
+        <TableRow
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:text="ID token:"
+                android:id="@+id/textView6" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:id="@+id/txtIdToken"
+                android:singleLine="true" />
+        </TableRow>
+
+    </TableLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/scrollView"
+        android:layout_below="@+id/tableLayout">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/txtGd"
+            android:singleLine="false"
+            android:maxLines="5000"/>
+    </ScrollView>
+
+</RelativeLayout>

--- a/Aikuma/res/menu/main.xml
+++ b/Aikuma/res/menu/main.xml
@@ -37,7 +37,9 @@
 	<item android:id="@+id/help"
 		android:icon="@drawable/question"
 		android:title="@string/help"/>
-		<!--android:showAsAction="always"/>-->
+	<item android:id="@+id/debugInfo"
+		android:visible="false"
+		android:title="Debug Info"/>
 	<item android:id="@+id/about"
 		android:title="@string/about"/>
 </menu>

--- a/Aikuma/res/menu/menu_debug_info.xml
+++ b/Aikuma/res/menu/menu_debug_info.xml
@@ -1,0 +1,5 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" tools:context="org.lp20.aikuma.ui.DebugInfo">
+    <item android:id="@+id/action_settings" android:title="@string/action_settings"
+        android:orderInCategory="100" android:showAsAction="never" />
+</menu>

--- a/Aikuma/res/values-w820dp/dimens.xml
+++ b/Aikuma/res/values-w820dp/dimens.xml
@@ -1,0 +1,6 @@
+<resources>
+    <!-- Example customization of dimensions originally defined in res/values/dimens.xml
+         (such as screen margins) for screens with more than 820dp of available width. This
+         would include 7" and 10" devices in landscape (~960dp and ~1280dp respectively). -->
+    <dimen name="activity_horizontal_margin">64dp</dimen>
+</resources>

--- a/Aikuma/res/values/dimens.xml
+++ b/Aikuma/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<resources>
+    <!-- Default screen margins, per the Android Design guidelines. -->
+    <dimen name="activity_horizontal_margin">16dp</dimen>
+    <dimen name="activity_vertical_margin">16dp</dimen>
+</resources>

--- a/Aikuma/res/values/strings.xml
+++ b/Aikuma/res/values/strings.xml
@@ -52,4 +52,6 @@
 	<string name="http_ui_start">START</string>
 	<string name="http_ui_stop">STOP</string>
 	<string name="http_ui_default_port">8080</string>
+	<string name="title_activity_debug_info">DebugInfo</string>
+	<string name="action_settings">Settings</string>
 </resources>

--- a/Aikuma/src/org/lp20/aikuma/ui/DebugInfo.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/DebugInfo.java
@@ -1,0 +1,299 @@
+package org.lp20.aikuma.ui;
+
+import android.accounts.AccountManager;
+import android.app.Activity;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.Signature;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import org.lp20.aikuma.storage.DataStore;
+import org.lp20.aikuma.storage.FusionIndex;
+import org.lp20.aikuma.storage.FusionIndex2;
+import org.lp20.aikuma.storage.GoogleDriveStorage;
+import org.lp20.aikuma.storage.Index;
+import org.lp20.aikuma.util.AikumaSettings;
+import org.lp20.aikuma2.R;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DebugInfo extends Activity {
+    final String TAG = DebugInfo.class.getName();
+
+    String mEmail;
+    boolean mRecovering = false;
+    SharedPreferences mPref;
+    GoogleDriveStorage mGd;
+    FusionIndex2 mFi;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_debug_info);
+
+        ((TextView) findViewById(R.id.txtPkgName)).setText(getPackageName());
+        ((TextView) findViewById(R.id.txtFingerprint)).setText(appFingerprint());
+
+        /*
+        String[] accountTypes = new String[]{"com.google"};
+        Intent intent = AccountPicker.newChooseAccountIntent(null, null, accountTypes, false, null, null, null, null);
+        startActivityForResult(intent, 1004);
+        */
+        mEmail = AikumaSettings.getCurrentUserId();
+        ((TextView) findViewById(R.id.txtEmail)).setText(mEmail);
+
+        ((TextView) findViewById(R.id.txtOldToken)).setText(AikumaSettings.getCurrentUserToken());
+
+        mPref = PreferenceManager.getDefaultSharedPreferences(this);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        switch (requestCode) {
+            case 1004:
+                if (resultCode == RESULT_OK) {
+                    mEmail = data.getStringExtra(AccountManager.KEY_ACCOUNT_NAME);
+                    ((TextView) findViewById(R.id.txtEmail)).setText(mEmail);
+                } else if (resultCode == RESULT_CANCELED) {
+                    Toast.makeText(this, "You must select an account", Toast.LENGTH_SHORT).show();
+                }
+                break;
+            case 1008:
+                String[] toks = getTokens();
+                if (toks != null) {
+                    mPref.edit()
+                            .putString("access_token", toks[0])
+                            .putString("id_token", toks[1])
+                            .commit();
+                    displayTokens();
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    private String getScope() {
+        String joiner = "";
+        StringBuilder scopeBuilder = new StringBuilder("oauth2:");
+        for (String s : GoogleDriveStorage.getScopes()) {
+            scopeBuilder.append(joiner);
+            scopeBuilder.append(s);
+            joiner = " ";
+        }
+        for (String s: FusionIndex.getScopes()) {
+            scopeBuilder.append(joiner);
+            scopeBuilder.append(s);
+        }
+        return scopeBuilder.toString();
+    }
+
+    private String[] getTokens() {
+        /*
+        try {
+            return GoogleAuthUtil.getTokens(DebugInfo.this, mEmail, getScope());
+        } catch (IOException e) {
+            Log.i(TAG, "Failed to get access token (IOException)");
+        } catch (UserRecoverableAuthException e) {
+            if (mRecovering == false) {
+                mRecovering = true;
+                Intent intent = e.getIntent();
+                startActivityForResult(intent, 1008);
+                return null;
+            }
+        } catch (GoogleAuthException e) {
+            Log.i(TAG, "Failed to get access token (fatal): " + e.getMessage());
+        }
+        mRecovering = false;
+        return null;
+        */
+        return new String[]{
+            AikumaSettings.getCurrentUserToken(),
+            AikumaSettings.getCurrentUserIdToken()
+        };
+    }
+
+    public void runAuth(View view) {
+        new AsyncTask<Void, Void, String[]>() {
+            protected String[] doInBackground(Void... params) {
+                return getTokens();
+            }
+
+            protected void onPostExecute(String[] tokens) {
+                if (tokens == null)
+                    Log.i(TAG, "failed");
+                else {
+                    mPref.edit()
+                            .putString("access_token", tokens[0])
+                            .putString("id_token", tokens[1])
+                            .commit();
+                    mGd = new GoogleDriveStorage(tokens[0]);
+                    mFi = new FusionIndex2("", tokens[1], tokens[0]);
+                    displayTokens();
+                }
+            }
+        }.execute(null, null, null);
+    }
+
+    public void listDocs(View view) {
+        new AsyncTask<Void, Void, Void>() {
+            @Override
+            protected Void doInBackground(Void... params) {
+                mGd.list(new DataStore.ListItemHandler() {
+                    @Override
+                    public boolean processItem(String id, Date ts) {
+                        final String s = id;
+                        runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                appendText(s + "\n");
+                            }
+                        });
+                        return true;
+                    }
+                });
+                return null;
+            }
+        }.execute(null, null, null);
+    }
+
+    public void listIDs(View view) {
+        new AsyncTask<Void,Void,Void>() {
+            @Override
+            protected Void doInBackground(Void... params) {
+                Map<String, String> opt = new HashMap<String, String>();
+                mFi.search(opt, new Index.SearchResultProcessor() {
+                    @Override
+                    public boolean process(Map<String, String> record) {
+                        final Map<String,String> r = record;
+                        runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                appendText(r.get("identifier") + "\n");
+                            }
+                        });
+                        return true;
+                    }
+                });
+                return null;
+            }
+        }.execute();
+    }
+
+    public void clearLog(View view) {
+        ((TextView) findViewById(R.id.txtGd)).setText("");
+    }
+
+    private void appendText(String text) {
+        ((TextView) findViewById(R.id.txtGd)).append(text);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // Inflate the menu; this adds items to the action bar if it is present.
+        getMenuInflater().inflate(R.menu.menu_debug_info, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        // Handle action bar item clicks here. The action bar will
+        // automatically handle clicks on the Home/Up button, so long
+        // as you specify a parent activity in AndroidManifest.xml.
+        int id = item.getItemId();
+
+        //noinspection SimplifiableIfStatement
+        if (id == R.id.action_settings) {
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void displayTokens() {
+        String accessToken = mPref.getString("access_token", null);
+        String idToken = mPref.getString("id_token", null);
+        if (accessToken != null)
+            ((TextView) findViewById(R.id.txtAccessToken)).setText(accessToken);
+        if (idToken != null)
+            ((TextView) findViewById(R.id.txtIdToken)).setText(idToken);
+    }
+
+    private String appFingerprint() {
+        PackageManager pm = this.getPackageManager();
+        String packageName = this.getPackageName();
+        int flags = PackageManager.GET_SIGNATURES;
+
+        PackageInfo packageInfo = null;
+
+        try {
+            packageInfo = pm.getPackageInfo(packageName, flags);
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+            return null;
+        }
+        Signature[] signatures = packageInfo.signatures;
+
+        byte[] cert = signatures[0].toByteArray();
+
+        InputStream input = new ByteArrayInputStream(cert);
+
+        CertificateFactory cf = null;
+        try {
+            cf = CertificateFactory.getInstance("X509");
+        } catch (CertificateException e) {
+            e.printStackTrace();
+            return null;
+        }
+        X509Certificate c = null;
+        try {
+            c = (X509Certificate) cf.generateCertificate(input);
+        } catch (CertificateException e) {
+            e.printStackTrace();
+            return null;
+        }
+
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA1");
+            byte[] publicKey = md.digest(c.getEncoded());
+
+            StringBuffer hexString = new StringBuffer();
+            String prefix = "";
+            for (int i = 0; i < publicKey.length; i++) {
+                String appendString = Integer.toHexString(0xFF & publicKey[i]);
+                if (appendString.length() == 1) hexString.append("0");
+                hexString.append(prefix);
+                hexString.append(appendString.toUpperCase());
+                prefix = ":";
+            }
+
+            return hexString.toString();
+        } catch (CertificateEncodingException e) {
+            e.printStackTrace();
+            return null;
+        } catch (NoSuchAlgorithmException e1) {
+            e1.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/Aikuma/src/org/lp20/aikuma/ui/DebugInfo.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/DebugInfo.java
@@ -82,7 +82,7 @@ public class DebugInfo extends Activity {
                 String[] toks = getTokens();
                 if (toks != null) {
                     mPref.edit()
-                            .putString("access_token", toks[0])
+                            .putString(AikumaSettings.SETTING_AUTH_TOKEN_KEY, toks[0])
                             .putString("id_token", toks[1])
                             .commit();
                     displayTokens();
@@ -144,7 +144,7 @@ public class DebugInfo extends Activity {
                     Log.i(TAG, "failed");
                 else {
                     mPref.edit()
-                            .putString("access_token", tokens[0])
+                            .putString(AikumaSettings.SETTING_AUTH_TOKEN_KEY, tokens[0])
                             .putString("id_token", tokens[1])
                             .commit();
                     mGd = new GoogleDriveStorage(tokens[0]);
@@ -231,7 +231,7 @@ public class DebugInfo extends Activity {
     }
 
     private void displayTokens() {
-        String accessToken = mPref.getString("access_token", null);
+        String accessToken = mPref.getString(AikumaSettings.SETTING_AUTH_TOKEN_KEY, null);
         String idToken = mPref.getString("id_token", null);
         if (accessToken != null)
             ((TextView) findViewById(R.id.txtAccessToken)).setText(accessToken);

--- a/Aikuma/src/org/lp20/aikuma/ui/MenuBehaviour.java
+++ b/Aikuma/src/org/lp20/aikuma/ui/MenuBehaviour.java
@@ -144,6 +144,10 @@ public class MenuBehaviour {
 				intent = new Intent(activity, SyncSettingsActivity.class);
 				activity.startActivity(intent);
 				return true;
+            case R.id.debugInfo:
+                intent = new Intent(activity, DebugInfo.class);
+                activity.startActivity(intent);
+                return true;
 			default:
 				return true;
 		}


### PR DESCRIPTION
I added an activity for debugging purposes. The UI displays some debugging information and provides buttons for checking if could is functional. I thought I would keep this UI for later use.

The activity is not visible. The menu item that triggers this activity is hidden from the menu (see res/menu/main.xml). So, it should be made visible to use it.