### PR TITLE
Directory hierarchy and new file sharing

### DIFF
--- a/AikumaCloudStorage/demo/DownloadFile.java
+++ b/AikumaCloudStorage/demo/DownloadFile.java
@@ -4,19 +4,34 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.Properties;
 
 import org.lp20.aikuma.storage.GoogleDriveStorage;
+import org.lp20.aikuma.storage.DataStore;
 import org.lp20.aikuma.storage.Utils;
 
 
 public class DownloadFile {
 	public static void main(String argv[]) {
-		if (argv.length != 2) {
-			System.out.println("Usage: DownloadFile <identifier> <access_token>");
+		if (argv.length != 1) {
+			System.out.println("Usage: DownloadFile <identifier>");
 			System.exit(1);
 		}
 		
-		GoogleDriveStorage gd = new GoogleDriveStorage(argv[1]);
+
+		Properties config = DemoUtils.readProps();
+		String accessToken = config.getProperty("access_token");
+		String rootId = config.getProperty("aikuma_root_id");
+		String email = config.getProperty("central_drive_email");
+
+		GoogleDriveStorage gd;
+		try {
+			gd = new GoogleDriveStorage(accessToken, rootId, email);
+		} catch (DataStore.StorageException e) {
+			System.out.println("Failed to initialize GD");
+			System.exit(1);
+			return;
+		}
 		
 		InputStream is = gd.load(argv[0]);
 		if (is == null) {

--- a/AikumaCloudStorage/demo/GetAccessToken.java
+++ b/AikumaCloudStorage/demo/GetAccessToken.java
@@ -28,22 +28,22 @@ public class GetAccessToken {
 		for (String scope: FusionIndex.getScopes()) {
 			apis.add(scope);
 		}
-        if (true) {
-            URI uri = URI.create(auth.getAuthUrl(apis));
-            System.out.println("A google page will open where you can login and give permission to access your google drive.");
-            try {
-                desktop.browse(uri);
-            } catch (IOException e) {
-                System.err.println("Failed to open browser:");
-                System.err.println(e.getMessage());
-                System.exit(1);
-            }
-        } else {
-            // This is to support Bob's workflow, where he uses the non-default browser for Google stuff; ignore, please
-            System.out.println("Browse to this url, and grant permissions.");
-            System.out.println(auth.getAuthUrl(apis));
-            System.out.println();
-        }
+	        if (true) {
+			URI uri = URI.create(auth.getAuthUrl(apis));
+			System.out.println("A google page will open where you can login and give permission to access your google drive.");
+	    		try {
+			    	desktop.browse(uri);
+	    		} catch (IOException e) {
+				System.err.println("Failed to open browser:");
+				System.err.println(e.getMessage());
+				System.exit(1);
+	    		}
+		} else {
+		    	// This is to support Bob's workflow, where he uses the non-default browser for Google stuff; ignore, please
+			System.out.println("Browse to this url, and grant permissions.");
+			System.out.println(auth.getAuthUrl(apis));
+			System.out.println();
+		}
 
 
 		System.out.println("Once you give the permission, a new page opens with authorization code.");

--- a/AikumaCloudStorage/demo/ListFiles.java
+++ b/AikumaCloudStorage/demo/ListFiles.java
@@ -2,23 +2,24 @@ import java.util.Date;
 import java.util.Properties;
 
 import org.lp20.aikuma.storage.GoogleDriveStorage;
+import org.lp20.aikuma.storage.DataStore;
 
 
 public class ListFiles {
 	public static void main(String[] args) {
-		if (args.length > 1) {
-			System.out.println("Usage: ListFile [<access_token>]");
-			System.exit(1);
-		}
-		String accessToken;
-		if (args.length == 0) {
-		    Properties config = DemoUtils.readProps();
-		    accessToken = config.getProperty("access_token");
-		} else {
-		    accessToken = args[0];
-		}
+		Properties config = DemoUtils.readProps();
+		String accessToken = config.getProperty("access_token");
+		String rootId = config.getProperty("aikuma_root_id");
+		String email = config.getProperty("central_drive_email");
 
-		GoogleDriveStorage gd = new GoogleDriveStorage(accessToken);
+		GoogleDriveStorage gd;
+		try {
+			gd = new GoogleDriveStorage(accessToken, rootId, email);
+		} catch (DataStore.StorageException e) {
+			System.out.println("Failed to initialize GD");
+			System.exit(1);
+			return;
+		}
 		
 		gd.list(new GoogleDriveStorage.ListItemHandler() {
 			@Override

--- a/AikumaCloudStorage/demo/ListFiles.java
+++ b/AikumaCloudStorage/demo/ListFiles.java
@@ -24,8 +24,10 @@ public class ListFiles {
 		gd.list(new GoogleDriveStorage.ListItemHandler() {
 			@Override
 			public boolean processItem(String identifier, Date date) {
-				String datestr = date == null ? "?" : date.toString();
-				System.out.format("%s [%s]\n", identifier, datestr);
+				if (date == null)
+					System.out.format("[????-??-?? ??:??:?? ????] %s\n", identifier);
+				else
+					System.out.format("[%2$tF %2$tT%2$tz] %1s\n", identifier, date);
 				return true;
 			}
 		});

--- a/AikumaCloudStorage/demo/RefreshToken.java
+++ b/AikumaCloudStorage/demo/RefreshToken.java
@@ -1,0 +1,34 @@
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Properties;
+
+import java.util.logging.Logger;
+import java.util.logging.Level;
+import org.lp20.aikuma.storage.*;
+
+public class RefreshToken {
+	private static final Logger log = Logger.getLogger(GetAccessToken.class.getName());
+
+	public static void main(String[] args) {
+		Properties config = DemoUtils.readProps();
+		String clientId = config.getProperty("client_id");
+		String clientSecret = config.getProperty("client_secret");
+		String refreshToken = config.getProperty("refresh_token");
+		log.log(Level.INFO, "client id: " + clientId);
+		log.log(Level.INFO, "client secret: " + clientSecret);
+		log.log(Level.INFO, "refresh token: " + refreshToken);
+		log.log(Level.INFO, "old access token: " + config.getProperty("access_token"));
+		GoogleAuth auth = new GoogleAuth(clientId, clientSecret);
+		
+		if (auth.refreshAccessToken(refreshToken)) {
+			System.out.println("Access token: " + auth.getAccessToken());
+			config.put("access_token", auth.getAccessToken());
+			DemoUtils.writeProps(config);
+		}
+		else {
+			System.err.println("Failed to get access token.");
+			System.exit(1);
+		}
+	}
+}

--- a/AikumaCloudStorage/demo/ShareFile.java
+++ b/AikumaCloudStorage/demo/ShareFile.java
@@ -1,6 +1,7 @@
 import java.util.Date;
-
+import java.util.Properties;
 import org.lp20.aikuma.storage.GoogleDriveStorage;
+import org.lp20.aikuma.storage.DataStore;
 
 
 public class ShareFile {
@@ -9,14 +10,26 @@ public class ShareFile {
 	 * @param args
 	 */
 	public static void main(String[] args) {
-		if (args.length != 2) {
-			System.out.println("Usage: DownloadFile <access_token> <filename>");
+		if (args.length != 1) {
+			System.out.println("Usage: ShareFile <filename>");
 			System.exit(1);
 		}
 
-		GoogleDriveStorage gd = new GoogleDriveStorage(args[0]);
+		Properties config = DemoUtils.readProps();
+		String accessToken = config.getProperty("access_token");
+		String rootId = config.getProperty("aikuma_root_id");
+		String email = config.getProperty("central_drive_email");
+
+		GoogleDriveStorage gd;
+		try {
+			gd = new GoogleDriveStorage(accessToken, rootId, email);
+		} catch (DataStore.StorageException e) {
+			System.out.println("Failed to initialize GD");
+			System.exit(1);
+			return;
+		}
 		
-		if (gd.share(args[1]))
+		if (gd.share(args[0]))
 			System.out.println("Success");
 		else
 			System.out.println("Failure");

--- a/AikumaCloudStorage/demo/UploadFile.java
+++ b/AikumaCloudStorage/demo/UploadFile.java
@@ -6,27 +6,30 @@ import org.lp20.aikuma.storage.*;
 
 public class UploadFile {
 	public static void main(String args[]) {
-		if (args.length > 2 || args.length == 0) {
-			System.out.println("Usage: UploadFile <path> [<access_token>]");
+		if (args.length != 1) {
+			System.out.println("Usage: UploadFile <path>");
 			System.exit(1);
 		}
-		String accessToken;
-		if (args.length == 1) {
-			Properties config = DemoUtils.readProps();
-			accessToken = config.getProperty("access_token");
-		} else {
-			accessToken = args[0];
-		}
+		Properties config = DemoUtils.readProps();
+		String accessToken = config.getProperty("access_token");
+		String rootId = config.getProperty("aikuma_root_id");
+		String email = config.getProperty("central_drive_email");
 				
 		File file = new File(args[0]);
-		
 		Data data = Data.fromFile(file);
 		if (data == null) {
 			System.out.println("Failed to open file: " + args[0]);
 			System.exit(1);			
 		}
 		
-		GoogleDriveStorage gd = new GoogleDriveStorage(accessToken);
+		GoogleDriveStorage gd;
+		try {
+			gd = new GoogleDriveStorage(accessToken, rootId, email);
+		} catch (DataStore.StorageException e) {
+			System.out.println("Failed to initialize GD");
+			System.exit(1);
+			return;
+		}
 		
 		String download_url = gd.store(file.getName(), data);
 		if (download_url != null) {

--- a/AikumaCloudStorage/demo/UploadFile.java
+++ b/AikumaCloudStorage/demo/UploadFile.java
@@ -6,8 +6,8 @@ import org.lp20.aikuma.storage.*;
 
 public class UploadFile {
 	public static void main(String args[]) {
-		if (args.length != 1) {
-			System.out.println("Usage: UploadFile <path>");
+		if (args.length != 2) {
+			System.out.println("Usage: UploadFile <path> <identifier>");
 			System.exit(1);
 		}
 		Properties config = DemoUtils.readProps();
@@ -31,7 +31,7 @@ public class UploadFile {
 			return;
 		}
 		
-		String download_url = gd.store(file.getName(), data);
+		String download_url = gd.store(args[1], data);
 		if (download_url != null) {
 			System.out.println("OK");
 			System.out.println("File can be downloaded from " + download_url);

--- a/AikumaCloudStorage/gradle.properties
+++ b/AikumaCloudStorage/gradle.properties
@@ -1,2 +1,2 @@
-version=0.4.0
+version=0.5.0
 org.gradle.daemon=true

--- a/AikumaCloudStorage/logging.properties
+++ b/AikumaCloudStorage/logging.properties
@@ -1,0 +1,5 @@
+handlers = java.util.logging.ConsoleHandler
+.level=SEVERE
+org.lp20.aikuma.level=FINE
+java.util.logging.ConsoleHandler.level = FINE
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter

--- a/AikumaCloudStorage/logging.properties
+++ b/AikumaCloudStorage/logging.properties
@@ -1,5 +1,6 @@
 handlers = java.util.logging.ConsoleHandler
-.level=SEVERE
-org.lp20.aikuma.level=FINE
+.level = INFO
+org.lp20.aikuma.level = FINE
 java.util.logging.ConsoleHandler.level = FINE
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format = ******%n[%1$tF %1$tT] %4$-6s (%2$s) (%6$s)%n%5$s%n%n

--- a/AikumaCloudStorage/src/org/lp20/aikuma/storage/DataStore.java
+++ b/AikumaCloudStorage/src/org/lp20/aikuma/storage/DataStore.java
@@ -50,4 +50,6 @@ public interface DataStore {
 	 * @param handler
 	 */
 	public void list(ListItemHandler handler);
+
+	public class StorageException extends Exception {};
 }

--- a/AikumaCloudStorage/src/org/lp20/aikuma/storage/GoogleDriveStorage.java
+++ b/AikumaCloudStorage/src/org/lp20/aikuma/storage/GoogleDriveStorage.java
@@ -8,6 +8,10 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Stack;
+import java.util.NoSuchElementException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -25,7 +29,17 @@ import static org.lp20.aikuma.storage.Utils.gapi_connect;
 public class GoogleDriveStorage implements DataStore {
 	private static final Logger log = Logger.getLogger(GoogleDriveStorage.class.getName());
 
-	String accessToken_;
+	static final String DSVER_FIELD = "aikuma_ds_version";
+	static final String DSVER = "v01";
+	static final String ROOT_FIELD = "aikuma_root_id";
+	static final String PREFIX_FIELD = "aikuma_prefix";
+	static final String ROOT_FILE = "aikuma_root_id.txt";
+	static final String FOLDER_MIME = "application/vnd.google-apps.folder";
+
+	Map<String,String> mDirs;
+	String mAccessToken;
+	String mRootId;
+	String mCentralEmail;
 	
 	/**
 	 * GoogleDriveStorage allows saving and retrieving data to and from the
@@ -40,16 +54,39 @@ public class GoogleDriveStorage implements DataStore {
 	 * GoogleDriveStorage gd = new GoogleDriveStorage(auth.getAccessToken());
 	 * }
 	 * 
-	 * @param accessToken 
+	 * @param accessToken Access token for a google drive account.
+	 * @param rootId Globally unique identifier for the root directory.
+	 * @param centeralEmail Email address to share stored files with.
+	 *		Used by share() method. Shared files become public by
+	 *		the google drive corresponding to the email address.
 	 */
-	public GoogleDriveStorage(String accessToken) {
-		accessToken_ = accessToken;
+	public GoogleDriveStorage(
+			String accessToken,
+			String rootId,
+			String centralEmail)
+		throws DataStore.StorageException {
+		mAccessToken = accessToken;
+		mRootId = rootId;
+		mCentralEmail = centralEmail;
+		mDirs = new HashMap<String,String>();
+
+		initialize_aikuma_folder();
 	}
 	
 	@Override
 	public InputStream load(String identifier) {
-		String query = "trashed = false and title = \"" + identifier + "\"";
+		String query = String.format(
+				"trashed = false" +
+				" and title = '%s'" +
+				" and properties has {key='%s' and value='%s' and visibility='PUBLIC'}" +
+				" and properties has {key='%s' and value='%s' and visibility='PUBLIC'}",
+				escape_quote(basename(identifier)),
+				ROOT_FIELD, escape_quote(mRootId),
+				PREFIX_FIELD, escape_quote(dirname(identifier)));
+
 		JSONObject obj = gapi_list_files(query, null);
+
+		if (obj == null) return null;
 		JSONArray arr = (JSONArray) obj.get("items");
 		if (arr.size() == 0)
 			return null;
@@ -60,84 +97,90 @@ public class GoogleDriveStorage implements DataStore {
 
 	@Override
 	public String store(String identifier, Data data) {
-		// identifier - aikuma file path
-		JSONObject obj = gapi_insert(data);
-		if (obj == null) {
-			log.log(Level.INFO, "gapi_intert returned null");
-			return null;
-                }
-		
+		File f = new File(normpath(identifier));
+		String parentId = mkdir(f.getParent());
+
 		JSONObject meta = new JSONObject();
-		meta.put("title", identifier);
-		String fileid = (String) obj.get("id");
-		JSONObject obj2 = gapi_update_metadata(fileid, meta);
-		if (obj2 != null)
-			return (String) obj2.get("webContentLink");
-		else
-			return null;
+		meta.put("title", f.getName());
+
+		JSONArray parents = new JSONArray();
+		JSONObject parent = new JSONObject();
+		parent.put("id", parentId);
+		parents.add(parent);
+		meta.put("parents", parents);
+		meta.put("properties", getProp(mRootId, f.getPath()));
+
+		JSONObject obj = gapi_insert2(data, meta);
+		if (obj == null) return null;
+
+		return (String) obj.get("id");
 	}
 
 	@Override
 	public boolean share(String identifier) {
-		String name = "\"" + identifier.replaceAll("\"",  "\\\"") + "\"";
-		JSONObject obj = gapi_list_files("trashed = false and title = " + name, null);
+		String query = String.format(
+				"trashed = false" +
+				" and title = '%s'" +
+				" and properties has {key='%s' and value='%s' and visibility='PUBLIC'}" +
+				" and properties has {key='%s' and value='%s' and visibility='PUBLIC'}",
+				escape_quote(basename(identifier)),
+				ROOT_FIELD, escape_quote(mRootId),
+				PREFIX_FIELD, escape_quote(dirname(identifier)));
+
+		JSONObject obj = gapi_list_files(query, null);
 		
-		if (obj == null)
-			return false;  // "list" call failed
+		if (obj == null) return false;  // "list" call failed
 		
-		String kind = (String) obj.get("kind");
 		String fileid = null;
-		if (kind.equals("drive#fileList")) {
-			JSONArray arr = (JSONArray) obj.get("items");
-			if (arr != null && arr.size() > 0) {
-				JSONObject o = (JSONObject) arr.get(0);
-				fileid = (String) o.get("id");
-			}
+		JSONArray arr = (JSONArray) obj.get("items");
+		if (arr != null && arr.size() > 0) {
+			JSONObject o = (JSONObject) arr.get(0);
+			fileid = (String) o.get("id");
+		} else {
+			log.log(Level.FINE, "no file by identifier: " + identifier);
+			return false;
 		}
 		
-		if (fileid == null)
-			return false;  // unexpected response type
-		
-		JSONObject r = gapi_make_public(fileid);
-		if (r != null)
-			return true;
-		else
-			return false;
+		JSONObject r = gapi_share_with(fileid, mCentralEmail);
+		return r != null;
 	}
 	
 	@Override
 	public void list(ListItemHandler listItemHandler) {
-		JSONObject obj = gapi_list_files("trashed = false", null);
-		while (obj != null) {
-			log.log(Level.INFO, "processing list");
-			JSONArray arr = (JSONArray) obj.get("items");
-			for (Object item: arr) {
-				JSONObject o = (JSONObject) item;
-				String identifier = (String) o.get("title");
-				String datestr = (String) o.get("modifiedDate");
-				SimpleDateFormat datefmt = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-				Date date;
-				try {
-					date = datefmt.parse(datestr);
-				}
-				catch (ParseException e) {
-					date = null;
-				}
-				boolean cont = listItemHandler.processItem(identifier, date);
-				if (cont == false) {
-					log.log(Level.INFO, "handler stopped iteration");
-					return;
-				}
+		String query = String.format(
+				"trashed = false" +
+				" and mimeType != '" + FOLDER_MIME + "'" +
+				" and properties has {key='%s' and value='%s' and visibility='PUBLIC'}",
+				ROOT_FIELD,
+				mRootId.replaceAll("'", "\\'"));
+
+		for (Search e = search(query); e.hasMoreElements();) {
+			JSONObject o;
+			try {
+				o = e.nextElement();
+			} catch (Search.Error err) {
+				// TODO: need a way to pass exception to client
+				log.log(Level.FINE, "search failed");
+				return;
 			}
-			String nextPageToken = (String) obj.get("nextPageToken");
-			if (nextPageToken != null) {
-				obj = gapi_list_files(null, nextPageToken);
-			} else {
-				obj = null;
-				log.log(Level.INFO, "no more data to download");
+			String identifier;
+			Map<String,String> props = props_to_map(o.get("properties"));
+			if (props.containsKey(PREFIX_FIELD))
+				identifier = joinpath(props.get(PREFIX_FIELD), (String) o.get("title"));
+			else
+				identifier = "UNKNOWN";
+			String datestr = (String) o.get("modifiedDate");
+			SimpleDateFormat datefmt = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+			Date date;
+			try {
+				date = datefmt.parse(datestr.replaceAll("Z$"," GMT"));
+			} catch (ParseException err) {
+				date = null;
 			}
+			boolean cont = listItemHandler.processItem(identifier, date);
+			if (cont == false)
+				return;
 		}
-		log.log(Level.INFO, "gapi_list_files returned null");
 	}
 	
 	/**
@@ -147,11 +190,413 @@ public class GoogleDriveStorage implements DataStore {
 	 */
 	public static List<String> getScopes() {
 		ArrayList<String> apis = new ArrayList<String>();
-		apis.add("https://www.googleapis.com/auth/drive.file");
+		apis.add("https://www.googleapis.com/auth/drive");
 		return apis;
 	}
 	
 
+
+	private String normpath(String path) {
+		return path.replaceAll("^/*", "/");
+	}
+
+	private String joinpath(String p1, String p2) {
+		return p1.replaceAll("/*$","") + "/" + p2.replaceAll("^/*","");
+	}
+
+	private String dirname(String path) {
+		String p = (new File(normpath(path))).getParent();
+		return p == null ? "" : p;
+	}
+
+	private String basename(String path) {
+		return (new File(normpath(path))).getName();
+	}
+
+	private String escape_quote(String s) {
+		return s.replaceAll("'", "\\'");
+	}
+
+	private class Properties extends JSONArray {
+		public void put(String key, String value) {
+			JSONObject obj = new JSONObject();
+			obj.put("key", key);
+			obj.put("value", value);
+			obj.put("visibility", "PUBLIC");
+			add(obj);
+		}
+	}
+
+	private Properties getProp(String rootid, String path) {
+		Properties props = new GoogleDriveStorage.Properties();
+		props.put(DSVER_FIELD, DSVER);
+		props.put(ROOT_FIELD, rootid);
+		props.put(PREFIX_FIELD, dirname(path));
+		return props;
+	}
+
+	private abstract class Search {
+
+		String mNextPageToken;
+		int mNumItems;
+		int mIdx;
+		JSONArray mArr;
+		String mKind;
+		String mQuery;
+		boolean mErr;
+
+		public class Error extends Exception {}
+
+		public Search(String query, String kind) {
+			mKind = kind;
+			mQuery = query;
+			mNextPageToken = null;
+			mNumItems = 0;
+			mIdx = 0;
+			mErr = false;
+			processListObj(getMore(mQuery, mNextPageToken));
+		}
+
+		protected abstract JSONObject getMore(String query, String pageToken);
+
+		public boolean hasMoreElements() {
+			// if there is error, let them call nextElement() and handle error
+			return mErr || mNextPageToken != null || mNumItems > mIdx;
+		}
+
+		public JSONObject nextElement() throws NoSuchElementException, Error {
+			if (mErr)
+				throw new Error();
+			if (mNumItems <= mIdx && mNextPageToken != null)
+				processListObj(getMore(mQuery, mNextPageToken));
+			if (mNumItems > mIdx)
+				return (JSONObject) mArr.get(mIdx++);
+			else
+				throw new NoSuchElementException();
+		}
+
+		void processListObj(JSONObject obj) {
+			if (obj == null) {
+				log.log(Level.FINE, "received null");
+				mNextPageToken = null;
+				mNumItems = 0;
+				mIdx = 0;
+				mErr = true;
+			} else if (!mKind.equals((String) obj.get("kind"))) {
+				log.log(Level.FINE, "wrong kind received: " + (String) obj.get("kind"));
+				mErr = true;
+			} else {
+				mArr = (JSONArray) obj.get("items");
+				mIdx = 0;
+				mNumItems = mArr.size();
+				mNextPageToken = (String) obj.get("nextPageToken");
+				log.log(Level.FINE, "items: " + mNumItems + " next token: " + mNextPageToken);
+			}
+		}
+	}
+
+	private Search search(String query) {
+		return new Search(query, "drive#fileList") {
+			@Override
+			protected JSONObject getMore(String query, String pageToken) {
+				log.log(Level.FINE, "pageToken: " + pageToken + " query: " + query);
+				return gapi_list_files(query, pageToken);
+			}
+		};
+	}
+	
+	private void initialize_aikuma_folder() throws DataStore.StorageException {
+		String query = String.format(
+				"trashed = false " +
+				" and mimeType='%s'" +
+				" and properties has {key='%s' and value='%s' and visibility='PUBLIC'}",
+				FOLDER_MIME,
+				ROOT_FIELD,
+				escape_quote(mRootId));
+		
+		Search e = search(query);
+		if (e.hasMoreElements()) {
+			log.log(Level.FINE, "found aikumafied folders");
+			for (; e.hasMoreElements();) {
+				JSONObject o;
+				try {
+					o = e.nextElement();
+				} catch (Search.Error err) {
+					log.log(Level.FINE, "search exception");
+					throw new DataStore.StorageException();
+				}
+				Map<String,String> props = props_to_map(o.get("properties"));
+				String path;
+				String prefix = props.get(PREFIX_FIELD);
+				if ("".equals(prefix))
+					path = "/";
+				else
+					path = joinpath(prefix, (String) o.get("title"));
+				String fileid = (String) o.get("id");
+                                log.log(Level.FINE, "folder: " + fileid + " " + path);
+				if (path == null) {
+					log.log(Level.WARNING, "non-aikumafied directory found: " + (String) o.get("title"));
+				} else if (mDirs.containsKey(path)) {
+					log.log(Level.SEVERE, "multiple folders with same path found: " + path);
+					throw new DataStore.StorageException();
+				} else {
+					mDirs.put(path, fileid);
+				}
+			}
+			if (!mDirs.containsKey("/")) {
+				log.log(Level.FINE, "no aikumafied root found -- falling back");
+				mDirs.clear();
+				initialize_aikuma_folder2();
+			}
+
+		} else {
+			log.log(Level.FINE, "didn't find aikumafied dir structure, falling back");
+			initialize_aikuma_folder2();
+		}
+	}
+
+	private void initialize_aikuma_folder2() throws DataStore.StorageException {
+		String query = String.format(
+				"trashed = false and title = '%s'" +
+				" and mimeType != '%s'",
+				ROOT_FILE,
+				FOLDER_MIME);
+
+		Search e = search(query);
+		if (e.hasMoreElements()) {
+			ArrayList<String> parentIds = new ArrayList<String>();
+			for (; e.hasMoreElements();) {
+				JSONObject o;
+				try {
+					o = e.nextElement();
+				} catch (Search.Error err) {
+					log.log(Level.FINE, "search exception");
+					throw new DataStore.StorageException();
+				}
+
+				log.log(Level.FINE, "found " + ROOT_FILE + ", checking...");
+				InputStream is = gapi_download((String) o.get("downloadUrl"));
+				if (is == null) {
+					log.log(Level.FINE, "download failed");
+					throw new DataStore.StorageException();
+				}
+				String id;
+				try {
+					id = Utils.readStream(is).trim();
+				} catch (IOException err) {
+					log.log(Level.FINE, "error: " + err.getMessage());
+					throw new DataStore.StorageException();
+				}
+				if (id.equals(mRootId)) {
+					for (Object p: (JSONArray) o.get("parents")) {
+						String pid = (String) ((JSONObject) p).get("id");
+						parentIds.add(pid);
+					}
+				}
+			}
+			if (parentIds.size() == 0) {
+				log.log(Level.FINE, "failed to identify root folder containing the root id file");
+				initialize_aikuma_folder3();
+			} else if (parentIds.size() == 1) {
+				log.log(Level.FINE, "found manually created aikuma folder");
+				aikumafy(parentIds.get(0));
+			} else {
+				log.log(Level.FINE, "multiple Aikuma folders matching root id: " + mRootId);
+				throw new DataStore.StorageException();
+			}
+		} else {
+			initialize_aikuma_folder3();
+		}
+	}	
+
+	private void initialize_aikuma_folder3() throws DataStore.StorageException {
+		log.log(Level.FINE, "creating a new root");
+		JSONObject meta = new JSONObject();
+		meta.put("properties", getProp(mRootId, "/"));
+		meta.put("title", "aikuma");
+                meta.put("mimeType", FOLDER_MIME);
+		JSONObject res = gapi_make_file(meta);
+                if (res == null)
+                    throw new DataStore.StorageException();
+		String fid = (String) res.get("id");
+		mDirs.put("/", fid);
+	}
+
+	private void aikumafy(String fileid) throws DataStore.StorageException {
+		log.log(Level.FINE, "aikumafying folder: " + fileid);
+		Stack<String> stack = new Stack<String>();
+		stack.push(fileid);
+		stack.push("/");
+
+		String q = "trashed = false and '%s' in parents and mimeType='" + FOLDER_MIME + "'";
+		while (!stack.empty()) {
+			String base = stack.pop();
+			String pid = stack.pop();
+			mDirs.put(base, pid);
+			aikumafy_update_properties(pid, base);
+			for (Search e = search(String.format(q,pid)); e.hasMoreElements();) {
+				JSONObject c;
+				try {
+					c = e.nextElement();
+				} catch (Search.Error err) {
+					log.log(Level.FINE, "search exception");
+					throw new DataStore.StorageException();
+				}
+				String fid = (String) c.get("id");
+				String name = (String) c.get("title");
+				stack.push(fid);
+				stack.push(normpath(joinpath(base, name)));
+			}
+		}
+
+		q = "trashed=false and '%s' in parents and mimeType!='" + FOLDER_MIME + "'";
+		for (Object obj:  mDirs.keySet().toArray()) {
+			String path = (String) obj;
+			String pid = mDirs.get(path);
+			for (Search e = search(String.format(q,pid)); e.hasMoreElements();)
+				try {
+					aikumafy_update_properties(e.nextElement(), path);
+				} catch (Search.Error err) {
+					log.log(Level.FINE, "search exception");
+					throw new DataStore.StorageException();
+				}
+		}
+	}
+
+	private void aikumafy_update_properties(JSONObject child, String basedir) {
+		String fid = (String) child.get("id");
+		String name = (String) child.get("title");
+		String p = joinpath(basedir, name);
+		aikumafy_update_properties(fid, p);
+	}
+
+	private void aikumafy_update_properties(String fileid, String path) {
+		log.log(Level.FINE, "updating: " + path);
+		JSONObject meta = new JSONObject();
+		if (path != "/") {
+			File f = new File(path);
+			String parentId = mkdir(f.getParent());
+			JSONArray parents = new JSONArray();
+			JSONObject parent = new JSONObject();
+			parent.put("id", parentId);
+			parents.add(parent);
+			meta.put("parents", parents);
+			meta.put("title", f.getName());
+		}
+		meta.put("properties", getProp(mRootId, path));
+                log.log(Level.FINE, "setting properties for " + fileid + ": " + meta.toString());
+		gapi_update_metadata(fileid, meta);
+	}
+
+	private Map<String,String> props_to_map(Object props) {
+		HashMap<String,String> h = new HashMap<String,String>();
+		for (Object p: (JSONArray) props) {
+			JSONObject obj = (JSONObject) p;
+			h.put((String) obj.get("key"), (String) obj.get("value"));
+		}
+		return h;
+	}
+
+	private String mkdir(String path) {
+		File f = new File(path==null ? "/" : path);
+		String fid = mDirs.get(f.getPath());
+		if (fid == null) {
+			String parentFid = mkdir(f.getParent());
+
+			JSONObject meta = new JSONObject();
+			meta.put("properties", getProp(mRootId, f.getPath()));
+			meta.put("title", f.getName());
+			meta.put("mimeType", FOLDER_MIME);
+
+			JSONArray parents = new JSONArray();
+			JSONObject parent = new JSONObject();
+			parent.put("id", parentFid);
+			parents.add(parent);
+			meta.put("parents", parents);
+
+			JSONObject res = gapi_make_file(meta);
+			fid = (String) res.get("id");
+			mDirs.put(f.getPath(), fid);
+		}
+		return fid;
+	}
+
+	/**
+	 * Create an empty file or a folder with given metadata.
+	 * @param meta
+	 * @return JSONObject if succeeds, null, otherwise.
+	 */
+        private JSONObject gapi_make_file(JSONObject meta) {
+		try {
+			String metajson = meta.toString();
+			URL url = new URL("https://www.googleapis.com/drive/v2/files");
+			HttpURLConnection con = gapi_connect(url, "POST", mAccessToken);
+			con.setRequestProperty("Content-Type", "application/json");
+			con.setRequestProperty("Content-Length", String.valueOf(metajson.length()));
+			OutputStreamWriter writer = new OutputStreamWriter(con.getOutputStream());
+			writer.write(metajson);
+                        writer.flush();
+                        writer.close();
+
+			if (con.getResponseCode() != HttpURLConnection.HTTP_OK) {
+				log.log(Level.FINE, "http respose: " + con.getResponseCode() + " " + con.getResponseMessage());
+				return null;
+			}
+			
+			String json = Utils.readStream(con.getInputStream());
+			return (JSONObject) JSONValue.parse(json);
+		}
+		catch (IOException e) {
+			log.log(Level.FINE, "IO exception: " + e.getMessage());
+			return null;
+		}
+	}
+
+	/**
+	 * Create a new file with given content and metadata.
+	 * @param data
+	 * @param meta
+	 * @return JSONObject if succeeds, null, otherwise.
+	 */
+	private JSONObject gapi_insert2(Data data, JSONObject meta) {
+		log.log(Level.FINE, "metadata: " + meta.toString());
+		try {
+			URL url = new URL("https://www.googleapis.com/upload/drive/v2/files?uploadType=multipart");
+			HttpURLConnection con = gapi_connect(url, "POST", mAccessToken);
+			String bd = "bdbdbdbdbdbdbdbdbdbd";
+			con.setRequestProperty("Content-Type", "multipart/related; boundary=\"" + bd + "\"");
+			con.setChunkedStreamingMode(8192);
+			OutputStream os = con.getOutputStream();
+
+			os.write(("--" + bd + "\r\n").getBytes());
+			os.write("Content-Type: application/json\r\n".getBytes());
+			os.write("\r\n".getBytes());
+			os.write(meta.toString().getBytes());
+			os.write("\r\n".getBytes());
+
+			os.write(("--" + bd + "\r\n").getBytes());
+			os.write(("Content-Type: " + data.getMimeType() + "\r\n").getBytes());
+			os.write("\r\n".getBytes());
+			Utils.copyStream(data.getInputStream(), os, false);
+			os.write("\r\n".getBytes());
+
+			os.write(("--" + bd + "--\r\n").getBytes());
+			os.flush();
+			os.close();
+
+			if (con.getResponseCode() != HttpURLConnection.HTTP_OK) {
+				log.log(Level.FINE, "upload request http respose: " + con.getResponseCode() + " " + con.getResponseMessage());
+				return null;
+			}
+			
+			String json = Utils.readStream(con.getInputStream());
+			return (JSONObject) JSONValue.parse(json);
+		}
+		catch (IOException e) {
+			log.log(Level.FINE, "IO exception: " + e.getMessage());
+			return null;
+		}
+	}
 
 	/**
 	 * Upload a file.
@@ -161,14 +606,13 @@ public class GoogleDriveStorage implements DataStore {
 	private JSONObject gapi_insert(Data data) {		
 		try {
 			URL url = new URL("https://www.googleapis.com/upload/drive/v2/files?uploadType=media");
-			HttpURLConnection con = gapi_connect(url, "POST", accessToken_);
+			HttpURLConnection con = gapi_connect(url, "POST", mAccessToken);
 			con.setRequestProperty("Content-Type", data.getMimeType());
 			con.setChunkedStreamingMode(8192);
 			Utils.copyStream(data.getInputStream(), con.getOutputStream(), false);
 
 			if (con.getResponseCode() != HttpURLConnection.HTTP_OK) {
-				log.log(Level.INFO, "upload request http respose: " + con.getResponseCode());
-				log.log(Level.INFO, "response message: " + con.getResponseMessage());
+				log.log(Level.FINE, "upload request http respose: " + con.getResponseCode() + " " + con.getResponseMessage());
 				return null;
 			}
 			
@@ -176,7 +620,7 @@ public class GoogleDriveStorage implements DataStore {
 			return (JSONObject) JSONValue.parse(json);
 		}
 		catch (IOException e) {
-			log.log(Level.INFO, "IO exception: " + e.getMessage());
+			log.log(Level.FINE, "IO exception: " + e.getMessage());
 			return null;
 		}
 	}
@@ -191,7 +635,7 @@ public class GoogleDriveStorage implements DataStore {
 		try {
 			String metajson = obj.toJSONString();
 			URL url = new URL("https://www.googleapis.com/drive/v2/files/" + fileid);
-			HttpURLConnection con = gapi_connect(url, "PUT", accessToken_);
+			HttpURLConnection con = gapi_connect(url, "PUT", mAccessToken);
 			con.setRequestProperty("Content-Type", "application/json");
 			con.setRequestProperty("Content-Length", String.valueOf(metajson.length()));
 			OutputStreamWriter writer = new OutputStreamWriter(con.getOutputStream());
@@ -199,12 +643,15 @@ public class GoogleDriveStorage implements DataStore {
 			writer.flush();
 			writer.close();
 
-			if (con.getResponseCode() != HttpURLConnection.HTTP_OK)
-				return null;			
+			if (con.getResponseCode() != HttpURLConnection.HTTP_OK) {
+				log.log(Level.FINE, "update failed: " + con.getResponseCode() + " " + con.getResponseMessage() + " " + Utils.readStream(con.getInputStream()));
+				return null;
+			}
 			String json = Utils.readStream(con.getInputStream());
 			return (JSONObject) JSONValue.parse(json);
 		}
 		catch (IOException e) {
+			log.log(Level.FINE, "update failed: " + e.getMessage());
 			return null;
 		}
 	}
@@ -223,17 +670,25 @@ public class GoogleDriveStorage implements DataStore {
 				ub.addQuery("pageToken",  pageToken);
 			else if (searchQuery != null && !searchQuery.isEmpty())
 				ub.addQuery("q", searchQuery);
-			HttpURLConnection con = gapi_connect(ub.toUrl(), "GET", accessToken_);
+			HttpURLConnection con = gapi_connect(ub.toUrl(), "GET", mAccessToken);
 			if (con.getResponseCode() != HttpURLConnection.HTTP_OK) {
-				log.log(Level.INFO, "gapi_list_files http response: " + con.getResponseCode());
-				log.log(Level.INFO, "response messaage: " + con.getResponseMessage());
+				log.log(Level.FINE, "gapi_list_files http response: " + con.getResponseCode());
+				log.log(Level.FINE, "response messaage: " + con.getResponseMessage());
 				return null;
 			}
 			String json = Utils.readStream(con.getInputStream());
-			return (JSONObject) JSONValue.parse(json);
+			JSONObject obj = (JSONObject) JSONValue.parse(json);
+			String kind = (String) obj.get("kind");
+			if (kind.equals("drive#fileList")) {
+				return obj;
+			} else {
+				log.log(Level.FINE, "wrong kind of response received: " + kind);
+				log.log(Level.FINE, "drive#fileList was expected");
+				return null;
+			}
 		}
 		catch (IOException e) {
-			log.log(Level.INFO, "IO error: " + e.getMessage());
+			log.log(Level.FINE, "IO error: " + e.getMessage());
 			return null;
 		}
 	}
@@ -244,10 +699,16 @@ public class GoogleDriveStorage implements DataStore {
 	 * @return InputStream if successful, null otherwise.
 	 */
 	private InputStream gapi_download(String url) {
+		log.log(Level.FINE, "downloading from: " + url);
 		try {
-			HttpURLConnection con = gapi_connect(new URL(url), "GET", accessToken_);
-			if (con.getResponseCode() != HttpURLConnection.HTTP_OK)
+			HttpURLConnection con = gapi_connect(new URL(url), "GET", mAccessToken);
+			if (con.getResponseCode() != HttpURLConnection.HTTP_OK) {
+				log.log(Level.FINE, String.format(
+					"download failed: %d %s",
+					con.getResponseCode(),
+					con.getResponseMessage()));
 				return null;
+			}
 			return con.getInputStream();
 		}
 		catch (IOException e) {
@@ -256,20 +717,21 @@ public class GoogleDriveStorage implements DataStore {
 	}
 
 	/**
-	 * Make a file public.
+	 * Share a file with someone else.
 	 * @param fileid String file id.
+	 * @param email Email of the account to share the file with.
 	 * @return json response from the server.
 	 */
-	private JSONObject gapi_make_public(String fileid)
-	{
+	private JSONObject gapi_share_with(String fileid, String email) {
 		try {
 			JSONObject meta = new JSONObject();
-			meta.put("type", "anyone");
+			meta.put("type", "user");
+			meta.put("value", email);
 			meta.put("role", "reader");
 			String metajson = meta.toJSONString();
 			
 			URL url = new URL("https://www.googleapis.com/drive/v2/files/" + fileid + "/permissions");
-			HttpURLConnection con = gapi_connect(url, "POST", accessToken_);
+			HttpURLConnection con = gapi_connect(url, "POST", mAccessToken);
 			con.setRequestProperty("Content-Type", "application/json");
 			con.setRequestProperty("Content-Length", String.valueOf(metajson.length()));
 
@@ -284,7 +746,7 @@ public class GoogleDriveStorage implements DataStore {
 			return (JSONObject) JSONValue.parse(json);
 		}
 		catch (IOException e) {
-			System.out.println("exception");
+			log.log(Level.FINE, "exception: " + e.getMessage());
 			return null;
 		}
 	}


### PR DESCRIPTION
Directory hierarchy

1. Assume that all files under the root aikuma folder are tagged with
   properties:
   - aikuma_root_id: A unique identifier for the root folder
   - aikuma_prefix: Path of the folder containing the file or folder. The
     path is relative to the root folder.
   - aikuma_ds_version: Version of the directory structure spec

2. If there is no such directory structure described in 1, it falls back
   to look for a folder containing the aikuma_root_id.txt file whose
   content matches with the aikuma_root_id value.
   - If found, all files under the folder are tagged as described in 1.
     Files whose name is a path containing one or more slashed are
     transformed into a directory structure. For example, file "a/b/c" is
     trasnformed into directory "a" containing directory "b" containing
     file "c".

3. If there is no such folder described in 2, create a new root folder
   called "aikuma".

File sharing

The share method now shares the file with an email specified in the
constructor instead of making it world readable.

Constructor's signature has been changed. Two additional parameters were
added: the ID of the root folder, and the email address of the central
google drive.