### PR TITLE
Import shared files

### DIFF
--- a/AikumaCloudStorage/gradle.properties
+++ b/AikumaCloudStorage/gradle.properties
@@ -1,2 +1,2 @@
-version=0.5.0
+version=0.6.0
 org.gradle.daemon=true

--- a/AikumaCloudStorage/gradle.properties
+++ b/AikumaCloudStorage/gradle.properties
@@ -1,2 +1,2 @@
-version=0.6.0
+version=0.6.1
 org.gradle.daemon=true

--- a/AikumaCloudStorage/gradle.properties
+++ b/AikumaCloudStorage/gradle.properties
@@ -1,2 +1,2 @@
-version=0.6.1
+version=0.7.0
 org.gradle.daemon=true

--- a/AikumaCloudStorage/src/org/lp20/aikuma/storage/GoogleDriveFolderCache.java
+++ b/AikumaCloudStorage/src/org/lp20/aikuma/storage/GoogleDriveFolderCache.java
@@ -1,0 +1,178 @@
+package org.lp20.aikuma.storage;
+
+import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * The GoogleDriveFolderCache class keeps the directory paths and Google file
+ * IDs for fast access without calling Google API.
+ *
+ * This is a singleton, so use getInstance() to get the instance.
+ *
+ * The cache can be built in 2 ways. One is to add 3-tuple of Google file ID,
+ * directory name (title), and Google file ID of the parent directory. Before
+ * starting adding tuples, beginTable() should be called, and finishTable()
+ * should be called after all tuples have been added. This approach requires
+ * a little care regarding thread synchronization. Because beginTable()
+ * creates a lock, finishTable() must be called to unlock.
+ *
+ * Another way of building the cache is to explicitly add path and Google file
+ * ID pairs. Use add() to add a pair. Use getFid() and getPath() to get Google
+ * File ID and directory path respectively.
+ */
+class GoogleDriveFolderCache {
+	final Map<String,String> mFids = new HashMap<String,String>();
+	final Map<String,String> mPaths = new HashMap<String,String>();
+	Map<String,String> mNames;
+	Map<String,Set<String>> mPids0;
+	Map<String,String> mPids;
+	private final ReentrantLock lock = new ReentrantLock();
+	private static GoogleDriveFolderCache mObj = null;
+
+	private GoogleDriveFolderCache() {
+	}
+
+	/**
+	 * Get the singletone instance of the class.
+	 */
+	public static synchronized GoogleDriveFolderCache getInstance() {
+		if (mObj == null)
+			mObj = new GoogleDriveFolderCache();
+		return mObj;
+	}
+
+	/**
+	 * This exception signals a problem in building the cache.
+	 */
+	public class Error extends Exception {
+		public Error(String message) {
+			super(message);
+		}
+	}
+
+	private String computePath(String id) throws Error {
+		if (mPaths.containsKey(id)) {
+			return mPaths.get(id);
+		}
+		
+		String path;
+		if (mPids.containsKey(id)) {
+			String prefix = computePath(mPids.get(id));
+                        String joiner = prefix.equals("/") ? "" : "/";
+                        path = prefix + joiner + mNames.get(id);
+		} else {
+			path = "/";
+		}
+
+		mPaths.put(id, path);
+		if (mFids.containsKey(path)) {
+			String msg = String.format("folder maps to multiple paths: %s (%s)", path, id);
+			throw new Error(msg);
+		}
+		mFids.put(path, id);
+		return path;
+	}
+
+	/**
+	 * Start building the cache.
+	 *
+	 * This is one way of building the cache. After this, use addToTable() to
+	 * add materials to build the cache, and then call finishTable() to finalize
+	 * building the cache.
+	 */
+	public void beginTable() {
+		lock.lock();
+		mNames = new HashMap<String,String>();
+		mPids0 = new HashMap<String,Set<String>>();
+		mPids = new HashMap<String,String>();
+	}
+
+	/**
+	 * Add information for a directory which is later used to build the cache.
+	 *
+	 * @param id Google file ID of the directory.
+	 * @param title Name of the directory.
+	 * @param pid Google file ID of the parent directory.
+	 */
+	public void addToTable(String id, String title, String pid) {
+		mNames.put(id, title);
+		if (!mPids0.containsKey(id))
+			mPids0.put(id, new HashSet<String>());
+		mPids0.get(id).add(pid);
+	}
+
+	/**
+	 * Build the cache using the information added by addToTable().
+	 */
+	public void finishTable() throws Error {
+		for (String id: mPids0.keySet()) {
+			for (String pid: mPids0.get(id)) {
+				if (mNames.containsKey(pid)) {
+					mPids.put(id, pid);
+				}
+			}
+		}
+		try {
+			for (String id: mNames.keySet())
+				computePath(id);
+		} catch (Error err) {
+			throw err;
+		} finally {
+			mPids = null;
+			mPids0 = null;
+			mNames = null;
+			lock.unlock();
+		}
+	}
+
+	/**
+	 * Empty the cache.
+	 */
+	public synchronized void clear() {
+		mPaths.clear();
+		mFids.clear();
+	}
+
+	/**
+	 * Add Google file ID and path pair.
+	 *
+	 * This is the second way of building the cache. The Google file ID and
+	 * directory path are explicitly added.
+	 *
+	 * @param id Google file ID.
+	 * @param path Path of the directory.
+	 */
+	public synchronized void add(String id, String path) {
+		mPaths.put(id, path);
+		mFids.put(path, id);
+	}
+
+	/**
+	 * Get directory path corresponding to the given Google file ID.
+	 *
+	 * @param id Google file ID.
+	 * @return Directory path.
+	 */
+	public synchronized String getPath(String id) {
+		return mPaths.get(id);
+	}
+
+	/**
+	 * Get Google file ID corresponding to the give directory path.
+	 *
+	 * @param path Directory path.
+	 * @return Google file ID.
+	 */
+	public synchronized String getFid(String path) {
+		return mFids.get(path);
+	}
+
+	/**
+	 * Get list of all directory paths.
+	 *
+	 * @return List of directory paths.
+	 */
+	public synchronized List<String> listPaths() {
+		return new ArrayList<String>(mFids.keySet());
+	}
+}

--- a/AikumaCloudStorage/src/org/lp20/aikuma/storage/GoogleDriveStorage.java
+++ b/AikumaCloudStorage/src/org/lp20/aikuma/storage/GoogleDriveStorage.java
@@ -5,21 +5,11 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Stack;
-import java.util.NoSuchElementException;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.JSONValue;
-
-import static org.lp20.aikuma.storage.Utils.gapi_connect;
+import org.json.simple.*;
 
 /**
  * Implementation of DataStore backed by Google Drive.
@@ -32,11 +22,13 @@ public class GoogleDriveStorage implements DataStore {
 	static final String DSVER_FIELD = "aikuma_ds_version";
 	static final String DSVER = "v01";
 	static final String ROOT_FIELD = "aikuma_root_id";
-	static final String PREFIX_FIELD = "aikuma_prefix";
 	static final String ROOT_FILE = "aikuma_root_id.txt";
+        static final String PREFIX_FIELD = "aikuma_prefix";
 	static final String FOLDER_MIME = "application/vnd.google-apps.folder";
 
-	Map<String,String> mDirs;
+	GoogleDriveFolderCache mCache;
+	static boolean mCacheInitialized = false;
+
 	String mAccessToken;
 	String mRootId;
 	String mCentralEmail;
@@ -68,21 +60,31 @@ public class GoogleDriveStorage implements DataStore {
 		mAccessToken = accessToken;
 		mRootId = rootId;
 		mCentralEmail = centralEmail;
-		mDirs = new HashMap<String,String>();
 
-		initialize_aikuma_folder();
+		mCache = GoogleDriveFolderCache.getInstance();
+		if (mCacheInitialized == false) {
+			initialize_aikuma_folder();
+			mCacheInitialized = true;
+		}
 	}
 	
 	@Override
 	public InputStream load(String identifier) {
+		String prefix = dirname(identifier);
+		String pid = mCache.getFid(prefix);
+		if (pid == null) {
+			log.log(Level.FINE, "containing folder doesn't exist: " + prefix);
+			return null;
+		}
+
 		String query = String.format(
 				"trashed = false" +
 				" and title = '%s'" +
 				" and properties has {key='%s' and value='%s' and visibility='PUBLIC'}" +
-				" and properties has {key='%s' and value='%s' and visibility='PUBLIC'}",
+				" and '%s' in parents",
 				escape_quote(basename(identifier)),
 				ROOT_FIELD, escape_quote(mRootId),
-				PREFIX_FIELD, escape_quote(dirname(identifier)));
+				pid);
 
 		JSONObject obj = gapi_list_files(query, null);
 
@@ -108,7 +110,7 @@ public class GoogleDriveStorage implements DataStore {
 		parent.put("id", parentId);
 		parents.add(parent);
 		meta.put("parents", parents);
-		meta.put("properties", getProp(mRootId, f.getPath()));
+		meta.put("properties", getProp(f.getParent()));
 
 		JSONObject obj = gapi_insert2(data, meta);
 		if (obj == null) return null;
@@ -118,14 +120,21 @@ public class GoogleDriveStorage implements DataStore {
 
 	@Override
 	public boolean share(String identifier) {
+		String prefix = dirname(identifier);
+		String pid = mCache.getFid(prefix);
+		if (pid == null) {
+			log.log(Level.FINE, "containing folder doesn't exist: " + prefix);
+			return false;
+		}
+
 		String query = String.format(
 				"trashed = false" +
 				" and title = '%s'" +
 				" and properties has {key='%s' and value='%s' and visibility='PUBLIC'}" +
-				" and properties has {key='%s' and value='%s' and visibility='PUBLIC'}",
+				" and '%s' in parents",
 				escape_quote(basename(identifier)),
 				ROOT_FIELD, escape_quote(mRootId),
-				PREFIX_FIELD, escape_quote(dirname(identifier)));
+				pid);
 
 		JSONObject obj = gapi_list_files(query, null);
 		
@@ -163,12 +172,16 @@ public class GoogleDriveStorage implements DataStore {
 				log.log(Level.FINE, "search failed");
 				return;
 			}
-			String identifier;
-			Map<String,String> props = props_to_map(o.get("properties"));
-			if (props.containsKey(PREFIX_FIELD))
-				identifier = joinpath(props.get(PREFIX_FIELD), (String) o.get("title"));
-			else
-				identifier = "UNKNOWN";
+			String identifier = "UNKNOWN";
+			for (Object pidObj: (JSONArray) o.get("parents")) {
+				JSONObject parent = (JSONObject) pidObj;
+				String pid = (String) parent.get("id");
+				String prefix = mCache.getPath(pid);
+				if (prefix != null) {
+					identifier = joinpath(prefix, (String) o.get("title")).replaceAll("^/*","");
+					break;
+				}
+			}
 			String datestr = (String) o.get("modifiedDate");
 			SimpleDateFormat datefmt = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 			Date date;
@@ -227,11 +240,11 @@ public class GoogleDriveStorage implements DataStore {
 		}
 	}
 
-	private Properties getProp(String rootid, String path) {
+	private Properties getProp(String prefix) {
 		Properties props = new GoogleDriveStorage.Properties();
 		props.put(DSVER_FIELD, DSVER);
-		props.put(ROOT_FIELD, rootid);
-		props.put(PREFIX_FIELD, dirname(path));
+		props.put(ROOT_FIELD, mRootId);
+                props.put(PREFIX_FIELD, prefix);
 		return props;
 	}
 
@@ -317,6 +330,7 @@ public class GoogleDriveStorage implements DataStore {
 		Search e = search(query);
 		if (e.hasMoreElements()) {
 			log.log(Level.FINE, "found aikumafied folders");
+			mCache.beginTable();
 			for (; e.hasMoreElements();) {
 				JSONObject o;
 				try {
@@ -325,30 +339,23 @@ public class GoogleDriveStorage implements DataStore {
 					log.log(Level.FINE, "search exception");
 					throw new DataStore.StorageException();
 				}
-				Map<String,String> props = props_to_map(o.get("properties"));
-				String path;
-				String prefix = props.get(PREFIX_FIELD);
-				if ("".equals(prefix))
-					path = "/";
-				else
-					path = joinpath(prefix, (String) o.get("title"));
-				String fileid = (String) o.get("id");
-                                log.log(Level.FINE, "folder: " + fileid + " " + path);
-				if (path == null) {
-					log.log(Level.WARNING, "non-aikumafied directory found: " + (String) o.get("title"));
-				} else if (mDirs.containsKey(path)) {
-					log.log(Level.SEVERE, "multiple folders with same path found: " + path);
-					throw new DataStore.StorageException();
-				} else {
-					mDirs.put(path, fileid);
+				String fid = (String) o.get("id");
+				String title = (String) o.get("title");
+				for (Object pidObj: (JSONArray) o.get("parents")) {
+					JSONObject parent = (JSONObject) pidObj;
+					mCache.addToTable(fid, title, (String) parent.get("id"));
 				}
 			}
-			if (!mDirs.containsKey("/")) {
+			try {
+				mCache.finishTable();
+			} catch (GoogleDriveFolderCache.Error err) {
+				throw new DataStore.StorageException();
+			}
+			if (mCache.getFid("/") == null) {
 				log.log(Level.FINE, "no aikumafied root found -- falling back");
-				mDirs.clear();
+				mCache.clear();
 				initialize_aikuma_folder2();
 			}
-
 		} else {
 			log.log(Level.FINE, "didn't find aikumafied dir structure, falling back");
 			initialize_aikuma_folder2();
@@ -387,6 +394,7 @@ public class GoogleDriveStorage implements DataStore {
 					log.log(Level.FINE, "error: " + err.getMessage());
 					throw new DataStore.StorageException();
 				}
+				log.log(Level.FINE, "downloaded root id: " + id + " vs " + mRootId);
 				if (id.equals(mRootId)) {
 					for (Object p: (JSONArray) o.get("parents")) {
 						String pid = (String) ((JSONObject) p).get("id");
@@ -412,14 +420,14 @@ public class GoogleDriveStorage implements DataStore {
 	private void initialize_aikuma_folder3() throws DataStore.StorageException {
 		log.log(Level.FINE, "creating a new root");
 		JSONObject meta = new JSONObject();
-		meta.put("properties", getProp(mRootId, "/"));
+		meta.put("properties", getProp("/"));
 		meta.put("title", "aikuma");
                 meta.put("mimeType", FOLDER_MIME);
 		JSONObject res = gapi_make_file(meta);
                 if (res == null)
                     throw new DataStore.StorageException();
 		String fid = (String) res.get("id");
-		mDirs.put("/", fid);
+		mCache.add(fid, "/");
 	}
 
 	private void aikumafy(String fileid) throws DataStore.StorageException {
@@ -432,7 +440,7 @@ public class GoogleDriveStorage implements DataStore {
 		while (!stack.empty()) {
 			String base = stack.pop();
 			String pid = stack.pop();
-			mDirs.put(base, pid);
+			mCache.add(pid, base);
 			aikumafy_update_properties(pid, base);
 			for (Search e = search(String.format(q,pid)); e.hasMoreElements();) {
 				JSONObject c;
@@ -450,9 +458,8 @@ public class GoogleDriveStorage implements DataStore {
 		}
 
 		q = "trashed=false and '%s' in parents and mimeType!='" + FOLDER_MIME + "'";
-		for (Object obj:  mDirs.keySet().toArray()) {
-			String path = (String) obj;
-			String pid = mDirs.get(path);
+		for (String path:  mCache.listPaths()) {
+			String pid = mCache.getFid(path);
 			for (Search e = search(String.format(q,pid)); e.hasMoreElements();)
 				try {
 					aikumafy_update_properties(e.nextElement(), path);
@@ -483,7 +490,7 @@ public class GoogleDriveStorage implements DataStore {
 			meta.put("parents", parents);
 			meta.put("title", f.getName());
 		}
-		meta.put("properties", getProp(mRootId, path));
+		meta.put("properties", getProp(dirname(path)));
                 log.log(Level.FINE, "setting properties for " + fileid + ": " + meta.toString());
 		gapi_update_metadata(fileid, meta);
 	}
@@ -499,12 +506,12 @@ public class GoogleDriveStorage implements DataStore {
 
 	private String mkdir(String path) {
 		File f = new File(path==null ? "/" : path);
-		String fid = mDirs.get(f.getPath());
+		String fid = mCache.getFid(f.getPath());
 		if (fid == null) {
 			String parentFid = mkdir(f.getParent());
 
 			JSONObject meta = new JSONObject();
-			meta.put("properties", getProp(mRootId, f.getPath()));
+			meta.put("properties", getProp(f.getParent()));
 			meta.put("title", f.getName());
 			meta.put("mimeType", FOLDER_MIME);
 
@@ -516,7 +523,7 @@ public class GoogleDriveStorage implements DataStore {
 
 			JSONObject res = gapi_make_file(meta);
 			fid = (String) res.get("id");
-			mDirs.put(f.getPath(), fid);
+			mCache.add(fid, f.getPath());
 		}
 		return fid;
 	}
@@ -530,7 +537,7 @@ public class GoogleDriveStorage implements DataStore {
 		try {
 			String metajson = meta.toString();
 			URL url = new URL("https://www.googleapis.com/drive/v2/files");
-			HttpURLConnection con = gapi_connect(url, "POST", mAccessToken);
+			HttpURLConnection con = Utils.gapi_connect(url, "POST", mAccessToken);
 			con.setRequestProperty("Content-Type", "application/json");
 			con.setRequestProperty("Content-Length", String.valueOf(metajson.length()));
 			OutputStreamWriter writer = new OutputStreamWriter(con.getOutputStream());
@@ -562,7 +569,7 @@ public class GoogleDriveStorage implements DataStore {
 		log.log(Level.FINE, "metadata: " + meta.toString());
 		try {
 			URL url = new URL("https://www.googleapis.com/upload/drive/v2/files?uploadType=multipart");
-			HttpURLConnection con = gapi_connect(url, "POST", mAccessToken);
+			HttpURLConnection con = Utils.gapi_connect(url, "POST", mAccessToken);
 			String bd = "bdbdbdbdbdbdbdbdbdbd";
 			con.setRequestProperty("Content-Type", "multipart/related; boundary=\"" + bd + "\"");
 			con.setChunkedStreamingMode(8192);
@@ -606,7 +613,7 @@ public class GoogleDriveStorage implements DataStore {
 	private JSONObject gapi_insert(Data data) {		
 		try {
 			URL url = new URL("https://www.googleapis.com/upload/drive/v2/files?uploadType=media");
-			HttpURLConnection con = gapi_connect(url, "POST", mAccessToken);
+			HttpURLConnection con = Utils.gapi_connect(url, "POST", mAccessToken);
 			con.setRequestProperty("Content-Type", data.getMimeType());
 			con.setChunkedStreamingMode(8192);
 			Utils.copyStream(data.getInputStream(), con.getOutputStream(), false);
@@ -635,7 +642,7 @@ public class GoogleDriveStorage implements DataStore {
 		try {
 			String metajson = obj.toJSONString();
 			URL url = new URL("https://www.googleapis.com/drive/v2/files/" + fileid);
-			HttpURLConnection con = gapi_connect(url, "PUT", mAccessToken);
+			HttpURLConnection con = Utils.gapi_connect(url, "PUT", mAccessToken);
 			con.setRequestProperty("Content-Type", "application/json");
 			con.setRequestProperty("Content-Length", String.valueOf(metajson.length()));
 			OutputStreamWriter writer = new OutputStreamWriter(con.getOutputStream());
@@ -670,10 +677,9 @@ public class GoogleDriveStorage implements DataStore {
 				ub.addQuery("pageToken",  pageToken);
 			else if (searchQuery != null && !searchQuery.isEmpty())
 				ub.addQuery("q", searchQuery);
-			HttpURLConnection con = gapi_connect(ub.toUrl(), "GET", mAccessToken);
+			HttpURLConnection con = Utils.gapi_connect(ub.toUrl(), "GET", mAccessToken);
 			if (con.getResponseCode() != HttpURLConnection.HTTP_OK) {
-				log.log(Level.FINE, "gapi_list_files http response: " + con.getResponseCode());
-				log.log(Level.FINE, "response messaage: " + con.getResponseMessage());
+				log.log(Level.FINE, "gapi_list_files http response: " + con.getResponseCode() + " " + con.getResponseMessage() + "; " + searchQuery);
 				return null;
 			}
 			String json = Utils.readStream(con.getInputStream());
@@ -701,7 +707,7 @@ public class GoogleDriveStorage implements DataStore {
 	private InputStream gapi_download(String url) {
 		log.log(Level.FINE, "downloading from: " + url);
 		try {
-			HttpURLConnection con = gapi_connect(new URL(url), "GET", mAccessToken);
+			HttpURLConnection con = Utils.gapi_connect(new URL(url), "GET", mAccessToken);
 			if (con.getResponseCode() != HttpURLConnection.HTTP_OK) {
 				log.log(Level.FINE, String.format(
 					"download failed: %d %s",
@@ -731,7 +737,7 @@ public class GoogleDriveStorage implements DataStore {
 			String metajson = meta.toJSONString();
 			
 			URL url = new URL("https://www.googleapis.com/drive/v2/files/" + fileid + "/permissions");
-			HttpURLConnection con = gapi_connect(url, "POST", mAccessToken);
+			HttpURLConnection con = Utils.gapi_connect(url, "POST", mAccessToken);
 			con.setRequestProperty("Content-Type", "application/json");
 			con.setRequestProperty("Content-Length", String.valueOf(metajson.length()));
 

--- a/AikumaCloudStorage/src/org/lp20/aikuma/storage/GoogleDriveStorage.java
+++ b/AikumaCloudStorage/src/org/lp20/aikuma/storage/GoogleDriveStorage.java
@@ -337,6 +337,11 @@ public class GoogleDriveStorage implements DataStore {
 					o = e.nextElement();
 				} catch (Search.Error err) {
 					log.log(Level.FINE, "search exception");
+                                        try {
+						mCache.finishTable();
+					} catch (Exception err2) {
+						// ignore
+					}
 					throw new DataStore.StorageException();
 				}
 				String fid = (String) o.get("id");


### PR DESCRIPTION
- When GoogleDriveStorage is instantiated, shared files are searched and
  *copied* into the aikuma folder.
- The folders to which the shared files are added are determined by
  their `aikuma_prefix` property.
- Copied files are also added to the `trash` directory inside the aikuma
  root folder. This is to distinguish newly shared files from the files
  that are already incorporated to the aikuma folder.
- Cloud storage version 0.7.0.

**Note that this branch was built on top of the branch in PR #395. This PR may have to be rebased after PR #395 is merged.**