### PR TITLE
add initialization param to GoogleDriveStorage

### DIFF
--- a/AikumaCloudStorage/build.gradle
+++ b/AikumaCloudStorage/build.gradle
@@ -42,5 +42,11 @@ project(':demo') {
     dependencies {
         compile project(':api')
     }
+
+    task fatJar(type: Jar) {
+        baseName = jar.baseName + '-all'
+        from { configurations.compile.collect {it.isDirectory() ? it : zipTree(it) } }
+        with jar
+    }
 }
 

--- a/AikumaCloudStorage/gradle.properties
+++ b/AikumaCloudStorage/gradle.properties
@@ -1,2 +1,2 @@
-version=0.7.1
+version=0.8.0
 org.gradle.daemon=true

--- a/AikumaCloudStorage/src/org/lp20/aikuma/storage/GoogleDriveStorage.java
+++ b/AikumaCloudStorage/src/org/lp20/aikuma/storage/GoogleDriveStorage.java
@@ -56,13 +56,19 @@ public class GoogleDriveStorage implements DataStore {
 	public GoogleDriveStorage(
 			String accessToken,
 			String rootId,
-			String centralEmail)
-		throws DataStore.StorageException {
+			String centralEmail,
+			boolean initialize)
+		throws DataStore.StorageException
+	{
 		mAccessToken = accessToken;
 		mRootId = rootId;
 		mCentralEmail = centralEmail;
 
 		mCache = GoogleDriveFolderCache.getInstance();
+                if (initialize == true) {
+                    mCacheInitialized = false;
+                    mCache.clear();
+                }
 		if (mCacheInitialized == false) {
 			initialize_aikuma_folder();
 			mCacheInitialized = true;
@@ -72,6 +78,15 @@ public class GoogleDriveStorage implements DataStore {
 		import_shared_files();
 	}
 	
+	public GoogleDriveStorage(
+			String accessToken,
+			String rootId,
+			String centralEmail)
+		throws DataStore.StorageException
+	{
+		this(accessToken, rootId, centralEmail, false);
+	}
+
 	@Override
 	public InputStream load(String identifier) {
 		String prefix = dirname(identifier);


### PR DESCRIPTION
- Added a new constructor that takes an additional paramater called
  initialize. If true, it will clear the existing cache and reconstruct it.
- 0.8.0 candidate