### PR TITLE
This PR is related to #562, #565

### DIFF
--- a/Aikuma/app/build.gradle
+++ b/Aikuma/app/build.gradle
@@ -42,9 +42,8 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:18.0.0'
+    compile 'com.google.android.gms:play-services-drive:8.4.0'
     compile 'com.google.guava:guava:13.0.1'
-    compile 'com.google.android.gms:play-services:5.0.89'
     compile files('libs/aikuma-cloud-storage-0.10.1.jar')
     compile files('libs/commons-io-2.4.jar')
     compile files('libs/commons-lang3-3.1.jar')

--- a/Aikuma/app/src/main/java/org/lp20/aikuma/model/FileModel.java
+++ b/Aikuma/app/src/main/java/org/lp20/aikuma/model/FileModel.java
@@ -4,6 +4,15 @@
 */
 package org.lp20.aikuma.model;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.util.Log;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.lp20.aikuma.util.FileIO;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -12,16 +21,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.apache.commons.lang3.StringUtils;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.lp20.aikuma.util.FileIO;
-import org.lp20.aikuma.util.IdUtils;
-
-import android.os.Parcel;
-import android.os.Parcelable;
-import android.util.Log;
 
 /**
  * The file modeled from the viewpoint of GoogleCloud
@@ -116,7 +115,11 @@ public class FileModel implements Parcelable {
 	public static final String VERSION_KEY = "version";
 	/** */
 	public static final String DATA_STORE_URI_KEY = "data_store_uri";
-	
+	/** */
+    public static final String DATE_CLOUD_KEY = "dat";
+    /** */
+    public static final String MULTI_META_CLOUD_DEFAULT_VAL = "mutli";
+
 	/**
 	 * Constructor of FileModel
 	 * 
@@ -332,11 +335,18 @@ public class FileModel implements Parcelable {
 		
 		String suffix;
 		if(fileType.equals(TAG_TYPE)) {
-			if(option != 0)
-				return null;
-			
-			String groupId = getId().split("-")[0];
-			return (ownerDirStr + Recording.TAG_PATH + groupId + "/" + getId());
+            String groupId = getId().split("-")[0];
+
+            if(option == 0) {
+                return (ownerDirStr + Recording.TAG_PATH + groupId + "/" + getId());
+            } else {
+                suffix = "." + Recording.AUDIO_EXT;
+                int tagValStart = id.lastIndexOf('-');
+                int tagKeyStart = id.substring(0, tagValStart).lastIndexOf('-');
+                String sourceCloudId = id.substring(0, tagKeyStart);
+
+                return (ownerDirStr + Recording.PATH + groupId + "/" + sourceCloudId + suffix);
+            }
 		} else if(fileType.equals(SPEAKER_TYPE)) {
 			suffix = getSuffixExt(versionName, FileType.METADATA);
 			

--- a/Aikuma/app/src/main/java/org/lp20/aikuma/model/Recording.java
+++ b/Aikuma/app/src/main/java/org/lp20/aikuma/model/Recording.java
@@ -5,34 +5,34 @@
 package org.lp20.aikuma.model;
 
 import android.graphics.Bitmap;
-import android.os.Environment;
 import android.os.Parcel;
 import android.util.Log;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
 import org.lp20.aikuma.Aikuma;
 import org.lp20.aikuma.util.AikumaSettings;
 import org.lp20.aikuma.util.FileIO;
 import org.lp20.aikuma.util.IdUtils;
 import org.lp20.aikuma.util.ImageUtils;
 import org.lp20.aikuma.util.StandardDateFormat;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.FileUtils;
-import org.json.simple.JSONObject;
-import org.json.simple.JSONArray;
-import org.json.simple.parser.JSONParser;
 
 import static junit.framework.Assert.assertTrue;
 


### PR DESCRIPTION
#562, #565
- Limitation of GoogleDrive Android API: no API for copy and share, only one scope is allowed(app-file scope)
- Sync with private GoogleDrive storage is now done by GoogleDrive Android API
- Custom property is used to store metadata instead of fullText
- Metadata JSON file is not uploaded as a file explicitly but stored in each recording's custom property. The JSON file is created when downloaded using the GoogleDrive's custom property.
  ( recording.wav, metadata.json <-> recording.wav(with meta) in GoogleDrive)
- Tagging the uploaded recording can now be reflected in GoogleDrive by changing the custom property  
